### PR TITLE
Update SBT Daffodil to 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,4 @@ organization := "com.tresys"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.12.18"
-
 enablePlugins(DaffodilPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "1.0.0")
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "1.+")


### PR DESCRIPTION
Use a version range so we do not need to update the plugins file for minor version updates